### PR TITLE
fix: wrong start for span when event starts before startOfWeek

### DIFF
--- a/src/calendarUtils.ts
+++ b/src/calendarUtils.ts
@@ -128,16 +128,16 @@ const getExcludedDays: Function = (startDate: Date, days: number, excluded: numb
 };
 
 const getWeekViewEventSpan: Function = (event: CalendarEvent, offset: number, startOfWeek: Date, excluded: number[]): number => {
+  const begin: Date = event.start < startOfWeek ? startOfWeek : event.start;
   let span: number = 1;
   if (event.end) {
-    const begin: Date = event.start < startOfWeek ? startOfWeek : event.start;
     span = differenceInDays(addMinutes(endOfDay(event.end), 1), startOfDay(begin));
   }
   const totalLength: number = offset + span;
   if (totalLength > DAYS_IN_WEEK) {
     span = DAYS_IN_WEEK - offset;
   }
-  return span - getExcludedDays(event.start, span, excluded);
+  return span - getExcludedDays(begin, span, excluded);
 };
 
 export const getWeekViewEventOffset: Function = (event: CalendarEvent, startOfWeek: Date, excluded: number[] = []): number => {

--- a/test/calendarUtils.spec.ts
+++ b/test/calendarUtils.spec.ts
@@ -191,6 +191,17 @@ describe('getWeekView', () => {
 
   });
 
+  it('should not include events that dont appear on the view when days are excluded', () => {
+    const events: CalendarEvent[] = [{
+      start: new Date('2016-01-08'),
+      end: new Date('2016-01-10'),
+      title: '',
+      color: {primary: '', secondary: ''}
+    }];
+    const eventCount: number = getWeekView({events, viewDate: new Date('2016-01-12'), excluded: [0, 6]}).length;
+    expect(eventCount).to.equal(0);
+  });
+
   it('should get the correct span, offset and extends values for events that start before the week and end after it', () => {
 
     const events: CalendarEvent[] = [{


### PR DESCRIPTION
fixes https://github.com/mattlewis92/angular-calendar/pull/155#issuecomment-285694468

/cc @mattlewis92 wrong start date was used to calculate the span
first event day was not excluded, default span 1 and excluded days between first event day +1 were zero. very good catch :D 