### PR TITLE
failing test cases with weekStartsOn and multiple weeks

### DIFF
--- a/src/calendarUtils.ts
+++ b/src/calendarUtils.ts
@@ -156,7 +156,6 @@ function getWeekViewEventSpan(
   {event: CalendarEvent, offset: number, startOfWeekDate: Date, excluded: number[], precision?: 'minutes' | 'days', weekStartsOn: number}
 ): number {
 
-  offset = Math.round(offset * SECONDS_IN_DAY);
   let span: number = SECONDS_IN_DAY;
   const begin: Date = max(event.start, startOfWeekDate);
   const endOfWeekDate: Date = endOfWeek(startOfWeekDate, {weekStartsOn});

--- a/src/calendarUtils.ts
+++ b/src/calendarUtils.ts
@@ -153,8 +153,8 @@ function calculateExcludedSeconds({precision, day, dayStart, dayEnd, startDate, 
 }
 
 function getWeekViewEventSpan(
-  {event, offset, startOfWeekDate, excluded, precision = 'days', weekStartsOn}:
-  {event: CalendarEvent, offset: number, startOfWeekDate: Date, excluded: number[], precision?: 'minutes' | 'days', weekStartsOn: number}
+  {event, offset, startOfWeekDate, excluded, precision = 'days'}:
+  {event: CalendarEvent, offset: number, startOfWeekDate: Date, excluded: number[], precision?: 'minutes' | 'days'}
 ): number {
 
   let span: number = SECONDS_IN_DAY;
@@ -316,7 +316,7 @@ export function getWeekView({
 
   const eventsMapped: WeekViewEvent[] = getEventsInPeriod({events, periodStart: startOfViewWeek, periodEnd: endOfViewWeek}).map(event => {
     let offset: number = getWeekViewEventOffset({event, startOfWeek: startOfViewWeek, excluded, precision});
-    let span: number = getWeekViewEventSpan({event, offset, startOfWeekDate: startOfViewWeek, excluded, precision, weekStartsOn});
+    let span: number = getWeekViewEventSpan({event, offset, startOfWeekDate: startOfViewWeek, excluded, precision});
     return {event, offset, span};
   }).filter(e => e.offset < maxRange).filter(e => e.span > 0).map(entry => ({
       event: entry.event,

--- a/src/calendarUtils.ts
+++ b/src/calendarUtils.ts
@@ -18,7 +18,6 @@ import startOfMinute from 'date-fns/start_of_minute';
 import differenceInMinutes from 'date-fns/difference_in_minutes';
 import addHours from 'date-fns/add_hours';
 import addSeconds from 'date-fns/add_seconds';
-import min from 'date-fns/min';
 import max from 'date-fns/max';
 
 const WEEKEND_DAY_NUMBERS: number[] = [0, 6];
@@ -26,6 +25,7 @@ const DAYS_IN_WEEK: number = 7;
 const HOURS_IN_DAY: number = 24;
 const MINUTES_IN_HOUR: number = 60;
 export const SECONDS_IN_DAY: number = 60 * 60 * 24;
+export const SECONDS_IN_WEEK: number = SECONDS_IN_DAY * DAYS_IN_WEEK;
 
 export interface WeekDay {
   date: Date;
@@ -119,14 +119,13 @@ function getExcludedSeconds({startDate, seconds, excluded, precision = 'days'}:
   if (excluded.length < 1) {
     return 0;
   }
+  const endDate: Date = addSeconds(startDate, seconds - 1);
   let result: number = 0; // Calculated in seconds
-  let endDate: Date;
   let dayStart: number ;
   let dayEnd: number;
 
   switch (precision) {
     case 'minutes':
-      endDate = addSeconds(startDate, seconds - 1);
       dayStart = getDay(startDate);
       dayEnd = getDay(addSeconds(endDate, 0));
       excluded.forEach(excludedDay => {
@@ -140,10 +139,13 @@ function getExcludedSeconds({startDate, seconds, excluded, precision = 'days'}:
       });
       break;
     case 'days':
-      endDate = addSeconds(startOfDay(startDate), seconds - 1);
-      dayStart = getDay(startOfDay(startDate));
-      dayEnd = getDay(endDate);
-      result += excluded.filter(excludedDay => excludedDay >= dayStart && excludedDay <= dayEnd).length * SECONDS_IN_DAY;
+      let current: Date = startDate;
+      while (current < endDate) {
+        if (excluded.some(day => getDay(current) === day)) {
+          result += SECONDS_IN_DAY;
+        }
+        current = addDays(current, 1);
+      }
       break;
   }
 
@@ -158,29 +160,28 @@ function getWeekViewEventSpan(
 
   let span: number = SECONDS_IN_DAY;
   const begin: Date = max(event.start, startOfWeekDate);
-  const endOfWeekDate: Date = endOfWeek(startOfWeekDate, {weekStartsOn});
 
   if (event.end) {
     switch (precision) {
-      case 'days':
-        span = (differenceInDays(
-          min(startOfDay(event.end), startOfDay(endOfWeekDate)),
-          startOfDay(begin)
-        ) + 1) * SECONDS_IN_DAY;
-        break;
       case 'minutes':
-        span = differenceInSeconds(
-          min(event.end, addSeconds(endOfWeekDate, 1)),
-          begin
-        );
+        span = differenceInSeconds(event.end, begin);
+        break;
+      default:
+        span = differenceInDays(addDays(event.end, 1), begin) * SECONDS_IN_DAY;
         break;
     }
-
   }
 
-  console.log(span / SECONDS_IN_DAY);
+  const offsetSeconds: number = offset * SECONDS_IN_DAY;
+  const totalLength: number = offsetSeconds + span;
+
+  // the best way to detect if an event is outside the week-view
+  // is to check if the total span beginning (from startOfWeekDay or event start) exceeds 7days
+  if (totalLength > SECONDS_IN_WEEK) {
+    span = SECONDS_IN_WEEK - offsetSeconds;
+  }
+
   span -= getExcludedSeconds({startDate: begin, seconds: span, excluded, precision});
-  console.log(span / SECONDS_IN_DAY);
 
   return span / SECONDS_IN_DAY;
 }
@@ -191,7 +192,7 @@ export function getWeekViewEventOffset({event, startOfWeek, excluded = [], preci
     return 0;
   }
 
-  let offset: number ;
+  let offset: number = 0;
 
   switch (precision) {
     case 'days':
@@ -317,7 +318,6 @@ export function getWeekView({
   const eventsMapped: WeekViewEvent[] = getEventsInPeriod({events, periodStart: startOfViewWeek, periodEnd: endOfViewWeek}).map(event => {
     let offset: number = getWeekViewEventOffset({event, startOfWeek: startOfViewWeek, excluded, precision});
     let span: number = getWeekViewEventSpan({event, offset, startOfWeekDate: startOfViewWeek, excluded, precision, weekStartsOn});
-
     return {event, offset, span};
   }).filter(e => e.offset < maxRange).filter(e => e.span > 0).map(entry => ({
       event: entry.event,

--- a/src/calendarUtils.ts
+++ b/src/calendarUtils.ts
@@ -178,7 +178,9 @@ function getWeekViewEventSpan(
 
   }
 
+  console.log(span / SECONDS_IN_DAY);
   span -= getExcludedSeconds({startDate: begin, seconds: span, excluded, precision});
+  console.log(span / SECONDS_IN_DAY);
 
   return span / SECONDS_IN_DAY;
 }

--- a/test/calendarUtils.spec.ts
+++ b/test/calendarUtils.spec.ts
@@ -159,6 +159,27 @@ describe('getWeekView', () => {
 
     });
 
+    it('should filter event if it exceeds the the view', () => {
+      const events: CalendarEvent[] = [{
+        start: new Date('2016-06-27'),
+        end: new Date('2016-06-27'),
+        title: '',
+        color: {primary: '', secondary: ''}
+      }];
+
+      const result: WeekViewEventRow[] = getWeekView({
+        events,
+        viewDate: new Date('2016-06-23'),
+        weekStartsOn: 4,
+        precision: 'days',
+        excluded: [1, 2, 3, 6]
+      });
+
+      expect(result).to.deep.equal([{
+        row: []
+      }]);
+    });
+
     it('should calculate correct span even if moved to another week by offset due to excludedDay', () => {
         const events: CalendarEvent[] = [{
           start: new Date('2017-05-31'),

--- a/test/calendarUtils.spec.ts
+++ b/test/calendarUtils.spec.ts
@@ -196,13 +196,15 @@ describe('getWeekView', () => {
         });
 
         const header: WeekDay[] = getWeekViewHeader({weekStartsOn, viewDate});
-        expect(header[0].date).eq(new Date('2017-05-26'));
-        expect(header[1].date).eq(new Date('2017-05-27'));
-        expect(header[2].date).eq(new Date('2017-05-28'));
-        expect(header[3].date).eq(new Date('2017-05-29'));
-        expect(header[4].date).eq(new Date('2017-05-30'));
-        expect(header[5].date).eq(new Date('2017-05-31'));
-        expect(header[6].date).eq(new Date('2017-06-01'));
+        const date: Date = startOfWeek(viewDate, {weekStartsOn});
+
+        expect(header[0].date.toISOString()).eq(date.toISOString());
+        expect(header[1].date.toISOString()).eq(addDays(date, 1).toISOString());
+        expect(header[2].date.toISOString()).eq(addDays(date, 2).toISOString());
+        expect(header[3].date.toISOString()).eq(addDays(date, 3).toISOString());
+        expect(header[4].date.toISOString()).eq(addDays(date, 4).toISOString());
+        expect(header[5].date.toISOString()).eq(addDays(date, 5).toISOString());
+        expect(header[6].date.toISOString()).eq(addDays(date, 6).toISOString());
 
         expect(result).to.deep.equal([{
           row: [{

--- a/test/calendarUtils.spec.ts
+++ b/test/calendarUtils.spec.ts
@@ -159,27 +159,6 @@ describe('getWeekView', () => {
 
     });
 
-    it('should filter event if it exceeds the the view', () => {
-      const events: CalendarEvent[] = [{
-        start: new Date('2016-06-27'),
-        end: new Date('2016-06-27'),
-        title: '',
-        color: {primary: '', secondary: ''}
-      }];
-
-      const result: WeekViewEventRow[] = getWeekView({
-        events,
-        viewDate: new Date('2016-06-23'),
-        weekStartsOn: 4,
-        precision: 'days',
-        excluded: [1, 2, 3, 6]
-      });
-
-      expect(result).to.deep.equal([{
-        row: []
-      }]);
-    });
-
     it('should calculate correct span even if moved to another week by offset due to excludedDay', () => {
         const events: CalendarEvent[] = [{
           start: new Date('2017-05-31'),
@@ -189,7 +168,11 @@ describe('getWeekView', () => {
         }];
 
         const result: WeekViewEventRow[] = getWeekView({
-          events, viewDate: new Date('2017-05-26'), weekStartsOn: 5, excluded: [0, 6], precision: 'days'
+          events,
+          viewDate: new Date('2017-05-26'),
+          weekStartsOn: 5,
+          excluded: [0, 6],
+          precision: 'days'
         });
         expect(result).to.deep.equal([{
           row: [{
@@ -230,7 +213,7 @@ describe('getWeekView', () => {
         expect(result).to.deep.equal([{
           row: [{
               event: events[0],
-              offset: 3,
+              offset: 5,
               span: 1,
               startsBeforeWeek: false,
               endsAfterWeek: false

--- a/test/calendarUtils.spec.ts
+++ b/test/calendarUtils.spec.ts
@@ -159,25 +159,25 @@ describe('getWeekView', () => {
 
     });
 
-    it('should calculate correct span even if moved to another week by offset due to excludedDay', () => {
+    it('should calculate correct span even if moved to another week by offset due to excludedDay and weekStartsOn offset', () => {
         const events: CalendarEvent[] = [{
-          start: new Date('2017-05-31'),
-          end: new Date('2017-05-31'),
+          start: new Date('2017-05-29'),
+          end: new Date('2017-05-29'),
           title: '',
           color: {primary: '', secondary: ''}
         }];
 
         const result: WeekViewEventRow[] = getWeekView({
           events,
-          viewDate: new Date('2017-05-26'),
-          weekStartsOn: 5,
+          viewDate: new Date('2017-05-24'),
+          weekStartsOn: 2,
           excluded: [0, 6],
           precision: 'days'
         });
         expect(result).to.deep.equal([{
           row: [{
               event: events[0],
-              offset: 3,
+              offset: 4,
               span: 1,
               startsBeforeWeek: false,
               endsAfterWeek: false
@@ -185,7 +185,7 @@ describe('getWeekView', () => {
         }]);
     });
 
-    it('should calculate correct span if multiple weeks are shown', () => {
+    it('should calculate correct span if multiple weeks are shown due to weekStartsOn offset', () => {
         const events: CalendarEvent[] = [{
           start: new Date('2017-05-31'),
           end: new Date('2017-05-31'),
@@ -193,27 +193,28 @@ describe('getWeekView', () => {
           color: {primary: '', secondary: ''}
         }];
 
-        const weekStartsOn: number = 5;
-        const viewDate: Date = new Date('2017-05-26');
+        const weekStartsOn: number = 6;
+        const viewDate: Date = new Date('2017-05-27');
         const result: WeekViewEventRow[] = getWeekView({
           events, viewDate, weekStartsOn, precision: 'days'
         });
 
         const header: WeekDay[] = getWeekViewHeader({weekStartsOn, viewDate});
-        const date: Date = startOfWeek(viewDate, {weekStartsOn});
+        const firstDayOfWeek: Date = startOfWeek(viewDate, {weekStartsOn});
 
-        expect(header[0].date.toISOString()).eq(date.toISOString());
-        expect(header[1].date.toISOString()).eq(addDays(date, 1).toISOString());
-        expect(header[2].date.toISOString()).eq(addDays(date, 2).toISOString());
-        expect(header[3].date.toISOString()).eq(addDays(date, 3).toISOString());
-        expect(header[4].date.toISOString()).eq(addDays(date, 4).toISOString());
-        expect(header[5].date.toISOString()).eq(addDays(date, 5).toISOString());
-        expect(header[6].date.toISOString()).eq(addDays(date, 6).toISOString());
+        expect(header.length).eq(7);
+        expect(header[0].date).to.deep.equal(firstDayOfWeek);
+        expect(header[1].date).to.deep.equal(addDays(firstDayOfWeek, 1));
+        expect(header[2].date).to.deep.equal(addDays(firstDayOfWeek, 2));
+        expect(header[3].date).to.deep.equal(addDays(firstDayOfWeek, 3));
+        expect(header[4].date).to.deep.equal(addDays(firstDayOfWeek, 4));
+        expect(header[5].date).to.deep.equal(addDays(firstDayOfWeek, 5));
+        expect(header[6].date).to.deep.equal(addDays(firstDayOfWeek, 6));
 
         expect(result).to.deep.equal([{
           row: [{
               event: events[0],
-              offset: 5,
+              offset: 4,
               span: 1,
               startsBeforeWeek: false,
               endsAfterWeek: false
@@ -1027,7 +1028,7 @@ describe('getWeekView', () => {
         weekStartsOn: 0,
         precision: 'minutes'
       });
-      expect(result[0].row[0].span).to.equal(4); // thuesday, thursday, friday, saturday
+      expect(result[0].row[0].span).to.equal(4); // tuesday, thursday, friday, saturday
       expect(result[0].row[0].offset).to.equal(1); // skip monday
       expect(result[0].row[0].endsAfterWeek).to.equal(true);
       expect(result[0].row[0].startsBeforeWeek).to.equal(false);

--- a/test/calendarUtils.spec.ts
+++ b/test/calendarUtils.spec.ts
@@ -141,7 +141,6 @@ describe('getWeekView', () => {
         color: {primary: '', secondary: ''}
       }];
 
-
       const result: WeekViewEventRow[] = getWeekView({
         events,
         viewDate: new Date('2016-06-27'),
@@ -160,8 +159,29 @@ describe('getWeekView', () => {
 
     });
 
-    it('should get the correct span, offset and extends values for events that start before the week and end within it', () => {
+    it('should calculate correct span even if moved by offset due to excludedDay', () => {
+        const events: CalendarEvent[] = [{
+          start: new Date('2017-05-31'),
+          end: new Date('2017-05-31'),
+          title: '',
+          color: {primary: '', secondary: ''}
+        }];
 
+        const result: WeekViewEventRow[] = getWeekView({
+          events, viewDate: new Date('2017-05-26'), weekStartsOn: 5, excluded: [0, 6], precision: 'days'
+        });
+        expect(result).to.deep.equal([{
+          row: [{
+              event: events[0],
+              offset: 3,
+              span: 1,
+              startsBeforeWeek: false,
+              endsAfterWeek: false
+          }]
+        }]);
+    });
+
+    it('should get the correct span, offset and extends values for events that start before the week and end within it', () => {
       const events: CalendarEvent[] = [{
         start: new Date('2016-06-24'),
         end: new Date('2016-06-29'),

--- a/test/calendarUtils.spec.ts
+++ b/test/calendarUtils.spec.ts
@@ -159,7 +159,7 @@ describe('getWeekView', () => {
 
     });
 
-    it('should calculate correct span even if moved by offset due to excludedDay', () => {
+    it('should calculate correct span even if moved to another week by offset due to excludedDay', () => {
         const events: CalendarEvent[] = [{
           start: new Date('2017-05-31'),
           end: new Date('2017-05-31'),
@@ -170,6 +170,40 @@ describe('getWeekView', () => {
         const result: WeekViewEventRow[] = getWeekView({
           events, viewDate: new Date('2017-05-26'), weekStartsOn: 5, excluded: [0, 6], precision: 'days'
         });
+        expect(result).to.deep.equal([{
+          row: [{
+              event: events[0],
+              offset: 3,
+              span: 1,
+              startsBeforeWeek: false,
+              endsAfterWeek: false
+          }]
+        }]);
+    });
+
+    it('should calculate correct span if multiple weeks are shown', () => {
+        const events: CalendarEvent[] = [{
+          start: new Date('2017-05-31'),
+          end: new Date('2017-05-31'),
+          title: '',
+          color: {primary: '', secondary: ''}
+        }];
+
+        const weekStartsOn: number = 5;
+        const viewDate: Date = new Date('2017-05-26');
+        const result: WeekViewEventRow[] = getWeekView({
+          events, viewDate, weekStartsOn, precision: 'days'
+        });
+
+        const header: WeekDay[] = getWeekViewHeader({weekStartsOn, viewDate});
+        expect(header[0].date).eq(new Date('2017-05-26'));
+        expect(header[1].date).eq(new Date('2017-05-27'));
+        expect(header[2].date).eq(new Date('2017-05-28'));
+        expect(header[3].date).eq(new Date('2017-05-29'));
+        expect(header[4].date).eq(new Date('2017-05-30'));
+        expect(header[5].date).eq(new Date('2017-05-31'));
+        expect(header[6].date).eq(new Date('2017-06-01'));
+
         expect(result).to.deep.equal([{
           row: [{
               event: events[0],


### PR DESCRIPTION
@mattlewis92 do you have any thoughts on this?
Looks like its a problem related to showing two weeks in one view (test uses Friday as viewDate (weekStartsOn) - Thursday, Weekend is excluded)

The span results in -4 (difference between end of week from Friday (26.) and the next Wednesday (31.))

Any quick idea? Am I missing something here?
If not I'll dive deeper into the latest changes

Edit 1: Happens also for views without excludedDays. `weekStartsOn` offset seems to be ignored
Edit 2: Demo for failing case [here](http://plnkr.co/edit/z6C98SmmuNbNTp3SlOTw?p=preview) (works for monthly view) 
Edit 3: Bug since 0.0.46