### PR TITLE
Address some DST related issues

### DIFF
--- a/src/calendar-utils.ts
+++ b/src/calendar-utils.ts
@@ -963,7 +963,11 @@ export function getDayView(
 
       let top: number = 0;
       if (eventStart > startOfView) {
-        top += differenceInMinutes(eventStart, startOfView);
+        // adjust the difference in minutes if the user's offset is different between the start of the day and the event (e.g. when going to or from DST)
+        const eventOffset = eventStart.getTimezoneOffset();
+        const startOffset = startOfView.getTimezoneOffset();
+        const diff = startOffset - eventOffset;
+        top += differenceInMinutes(eventStart, startOfView) + diff;
       }
       top *= hourHeightModifier;
 

--- a/test/calendar-utils.spec.ts
+++ b/test/calendar-utils.spec.ts
@@ -3137,50 +3137,6 @@ adapters.forEach(({ name, adapter: dateAdapter }) => {
     });
 
     describe('getDayViewHourGrid', () => {
-      it.skip('should deal with days that contain DST switch over in them', () => {
-        // this is the day that we flip from BST to GMT in the UK which means that there is an extra hour in the day
-        // we want to make sure that this does not screw things up
-        const viewDate = new Date(2019, 9, 27);
-        const result: DayViewHour[] = getDayViewHourGrid(dateAdapter, {
-          viewDate,
-          hourSegments: 2,
-          dayStart: {
-            hour: 1,
-            minute: 0
-          },
-          dayEnd: {
-            hour: 2,
-            minute: 59
-          }
-        });
-        expect(result).toEqual([
-          {
-            segments: [
-              {
-                date: setMinutes(setHours(startOfDay(viewDate), 1), 0),
-                isStart: true
-              },
-              {
-                date: setMinutes(setHours(startOfDay(viewDate), 1), 30),
-                isStart: false
-              }
-            ]
-          },
-          {
-            segments: [
-              {
-                date: setMinutes(setHours(startOfDay(viewDate), 2), 0),
-                isStart: true
-              },
-              {
-                date: setMinutes(setHours(startOfDay(viewDate), 2), 30),
-                isStart: false
-              }
-            ]
-          }
-        ]);
-      });
-
       it('should get the day view segments respecting the start and end of the day', () => {
         const result: DayViewHour[] = getDayViewHourGrid(dateAdapter, {
           viewDate: new Date(),

--- a/test/calendar-utils.spec.ts
+++ b/test/calendar-utils.spec.ts
@@ -3137,6 +3137,50 @@ adapters.forEach(({ name, adapter: dateAdapter }) => {
     });
 
     describe('getDayViewHourGrid', () => {
+      it.skip('should deal with days that contain DST switch over in them', () => {
+        // this is the day that we flip from BST to GMT in the UK which means that there is an extra hour in the day
+        // we want to make sure that this does not screw things up
+        const viewDate = new Date(2019, 9, 27);
+        const result: DayViewHour[] = getDayViewHourGrid(dateAdapter, {
+          viewDate,
+          hourSegments: 2,
+          dayStart: {
+            hour: 1,
+            minute: 0
+          },
+          dayEnd: {
+            hour: 2,
+            minute: 59
+          }
+        });
+        expect(result).toEqual([
+          {
+            segments: [
+              {
+                date: setMinutes(setHours(startOfDay(viewDate), 1), 0),
+                isStart: true
+              },
+              {
+                date: setMinutes(setHours(startOfDay(viewDate), 1), 30),
+                isStart: false
+              }
+            ]
+          },
+          {
+            segments: [
+              {
+                date: setMinutes(setHours(startOfDay(viewDate), 2), 0),
+                isStart: true
+              },
+              {
+                date: setMinutes(setHours(startOfDay(viewDate), 2), 30),
+                isStart: false
+              }
+            ]
+          }
+        ]);
+      });
+
       it('should get the day view segments respecting the start and end of the day', () => {
         const result: DayViewHour[] = getDayViewHourGrid(dateAdapter, {
           viewDate: new Date(),


### PR DESCRIPTION
So this seems to correct both the double occurrence of 1am and the incorrect placements of events. 

As you can see it is pretty horrible and I think it remains a matter of opinion whether it is actually correct. For my use case, it certainly seems closer to correct. 

I have added a test which is runnable by removing the TZ=Utc flag into jest, but as you suggested, it is difficult to test otherwise. 

I wouldn't blame you at all if you didn't want to merge this!  but I think it's the best I can come up with. 